### PR TITLE
feat: add uniswap pair for digg/wbtc

### DIFF
--- a/helpers/token_utils.py
+++ b/helpers/token_utils.py
@@ -18,7 +18,7 @@ def get_token_balances(accounts, tokens):
     return balances
 
 
-def distribute_from_whales(badger, recipient):
+def distribute_from_whales(recipient):
 
     console.print(
         "[green] 🐋 Transferring assets from whales for {} assets... 🐋 [/green]".format(
@@ -33,18 +33,7 @@ def distribute_from_whales(badger, recipient):
             continue
         if key != "_pytestfixturefunction":
             console.print(" -> {}".format(key))
-
-            if whale_config.action == WhaleRegistryAction.DISTRIBUTE_FROM_CONTRACT:
-                forceEther = ForceEther.deploy({"from": recipient})
-                recipient.transfer(forceEther, Wei("1 ether"))
-                forceEther.forceSend(whale_config.whale, {"from": recipient})
-
-            token = interface.IERC20(whale_config.token)
-            token.transfer(
-                recipient,
-                token.balanceOf(whale_config.whale) // 5,
-                {"from": whale_config.whale},
-            )
+            distribute_from_whale(whale_config, recipient)
 
     # Special Transfers
     for key, whale_config in whale_registry.items():
@@ -57,6 +46,20 @@ def distribute_from_whales(badger, recipient):
             sushiswap.addMaxLiquidity(
                 whale_config.actionParams["token0"], whale_config.actionParams["token1"], recipient
             )
+
+
+def distribute_from_whale(whale_config, recipient):
+    if whale_config.action == WhaleRegistryAction.DISTRIBUTE_FROM_CONTRACT:
+        forceEther = ForceEther.deploy({"from": recipient})
+        recipient.transfer(forceEther, Wei("1 ether"))
+        forceEther.forceSend(whale_config.whale, {"from": recipient})
+
+    token = interface.IERC20(whale_config.token)
+    token.transfer(
+        recipient,
+        token.balanceOf(whale_config.whale) // 5,
+        {"from": whale_config.whale},
+    )
 
 
 def distribute_test_ether(recipient, amount):

--- a/scripts/actions/deploy_honeypot.py
+++ b/scripts/actions/deploy_honeypot.py
@@ -18,7 +18,7 @@ console = Console()
 def main():
     badger = connect_badger(badger_config.prod_json)
     deployer = badger.deployer
-    # distribute_from_whales(badger, deployer)
+    # distribute_from_whales(deployer)
 
     # Deploy Honeypot
     honeypotLogic = HoneypotMeme.deploy({"from": deployer})

--- a/scripts/deploy/deploy_badger.py
+++ b/scripts/deploy/deploy_badger.py
@@ -156,7 +156,7 @@ def test_deploy(test=False, uniswap=True):
             badger_total_supply,
         )
         assert badger.token.balanceOf(deployer) == badger_total_supply
-        distribute_from_whales(badger, deployer)
+        distribute_from_whales(deployer)
 
         console.log("after whale funding", badger.token.balanceOf(deployer) / 1e18)
 

--- a/scripts/deploy/deploy_digg.py
+++ b/scripts/deploy/deploy_digg.py
@@ -5,6 +5,8 @@ from rich.console import Console
 from config.badger_config import digg_config, dao_config
 from scripts.systems.digg_system import DiggSystem, print_to_file, connect_digg
 from scripts.systems.digg_minimal import deploy_digg_minimal
+from helpers.token_utils import distribute_from_whale
+from helpers.registry import whale_registry
 
 console = Console()
 
@@ -23,6 +25,12 @@ def test_deploy(test=False, deploy=True):
         digg = deploy_digg_minimal(deployer, devProxyAdmin, daoProxyAdmin)
         digg.deploy_dao_digg_timelock()
         digg.deploy_digg_team_vesting()
+
+        if test:
+            # need some sweet liquidity for testing
+            distribute_from_whale(whale_registry.wbtc, digg.owner)
+        # deploy trading pairs (these deploys are always idempotent)
+        digg.deploy_uniswap_pairs(test=test)  # adds liqudity in test mode
     else:
         digg = connect_digg(digg_config.prod_json)
 

--- a/scripts/local_instance.py
+++ b/scripts/local_instance.py
@@ -27,9 +27,9 @@ def main():
     console.print("[blue]=== 🦡 Test ENV for account {} 🦡 ===[/blue]".format(user))
 
     distribute_test_ether(user, Wei("10 ether"))
-    distribute_from_whales(badger, user)
+    distribute_from_whales(user)
 
     console.print("[green]=== ✅ Test ENV Setup Complete ✅ ===[/green]")
     # Keep ganache open until closed
     time.sleep(days(365))
-        
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def badger_single_sett(settConfig):
         badger = connect_badger(badger_config.prod_json)
 
         distribute_test_ether(badger.deployer, Wei("20 ether"))
-        distribute_from_whales(badger, badger.deployer)
+        distribute_from_whales(badger.deployer)
 
         return badger
 
@@ -170,7 +170,7 @@ def badger_single_sett(settConfig):
 def badger_hunt_unit():
     deployer = accounts[0]
     badger = deploy_badger_minimal(deployer)
-    distribute_from_whales(badger, deployer)
+    distribute_from_whales(deployer)
 
     badger.deploy_logic("BadgerHunt", BadgerHunt)
     badger.deploy_badger_hunt()
@@ -186,7 +186,7 @@ def badger_hunt_unit():
 def badger_tree_unit():
     deployer = accounts[0]
     badger = deploy_badger_minimal(deployer)
-    distribute_from_whales(badger, deployer)
+    distribute_from_whales(deployer)
 
     badger.deploy_logic("BadgerHunt", BadgerHunt)
     badger.deploy_badger_hunt()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,7 +19,7 @@ def distribute_test_assets(badger):
     distribute_rewards_escrow(
         badger, badger.token, badger.deployer, Wei("100000 ether")
     )
-    distribute_from_whales(badger, badger.deployer)
+    distribute_from_whales(badger.deployer)
 
 
 def create_uniswap_pair(token0, token1, signer):
@@ -30,7 +30,7 @@ def create_uniswap_pair(token0, token1, signer):
     return uniswap.getPair(token0, token1)
 
 
-def distribute_from_whales(badger, recipient):
+def distribute_from_whales(recipient):
 
     print(len(whale_registry.items()))
     for key, whale in whale_registry.items():

--- a/tests/honeypot/test_meme_honeypot.py
+++ b/tests/honeypot/test_meme_honeypot.py
@@ -19,7 +19,7 @@ console = Console()
 def setup():
     badger = connect_badger(badger_config.prod_json)
     deployer = accounts.load("badger_deployer")
-    # distribute_from_whales(badger, deployer)
+    # distribute_from_whales(deployer)
 
     # Deploy Honeypot
     honeypotLogic = HoneypotMeme.deploy({"from": deployer})

--- a/tests/sett/fixtures/DiggMiniDeployBase.py
+++ b/tests/sett/fixtures/DiggMiniDeployBase.py
@@ -1,0 +1,48 @@
+from helpers.token_utils import distribute_from_whales, distribute_test_ether
+from scripts.systems.badger_minimal import deploy_badger_minimal
+from brownie import *
+
+
+class DiggMiniDeployBase:
+    def __init__(
+        self,
+        strategyName,
+        deployer,
+        strategist=None,
+        governance=None,
+        keeper=None,
+        guardian=None,
+    ):
+        self.strategyName = strategyName
+
+        if not strategist:
+            strategist = deployer
+        if not governance:
+            governance = deployer
+        if not keeper:
+            keeper = deployer
+        if not guardian:
+            guardian = deployer
+
+        self.strategist = strategist
+        self.governance = governance
+        self.keeper = keeper
+        self.guardian = guardian
+        self.deployer = deployer
+
+    def deploy(self):
+
+    def deploy_required_logic(self):
+
+    # ===== Specific instance must implement =====
+    def fetch_params(self):
+        return False
+
+    def pre_deploy_setup(self):
+        return False
+
+    def post_deploy_setup(self):
+        return False
+
+    def post_vault_deploy_setup(self):
+        return False

--- a/tests/sett/fixtures/SettMiniDeployBase.py
+++ b/tests/sett/fixtures/SettMiniDeployBase.py
@@ -19,7 +19,7 @@ class SettMiniDeployBase:
 
         if not strategist:
             strategist = deployer
-        if not governance:  
+        if not governance:
             governance = deployer
         if not keeper:
             keeper = deployer
@@ -48,7 +48,7 @@ class SettMiniDeployBase:
         self.want = want
 
         distribute_test_ether(self.deployer, Wei("20 ether"))
-        distribute_from_whales(self.badger, self.deployer)
+        distribute_from_whales(self.deployer)
 
         self.controller = self.badger.add_controller(self.key)
         self.vault = self.badger.deploy_sett(


### PR DESCRIPTION
Adds a uniswap pair for digg/wbtc in both deploy/connect path of digg system.

Exposes trading pair addresses as an attr on digg system -> `.uniswap_trading_pair_addrs` w/ key format `tokenA_tokenB`. 

Also includes some housekeeping on the `distribute_from_whales()` helper fn(s). Needed to distribute some wbtc so we can add liquidity to the uniswap digg/wbtc in tests.