### PR TITLE
test: add test for digg distributor

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,12 @@ from brownie import (
 
 from config.badger_config import badger_config, digg_config
 from scripts.deploy.deploy_badger import deploy_flow
+from scripts.deploy.deploy_digg import init_prod_digg
 from scripts.systems.badger_minimal import deploy_badger_minimal
 from scripts.systems.digg_minimal import deploy_digg_minimal
 from scripts.systems.constants import SettType
 from helpers.token_utils import distribute_test_ether
+from scripts.systems.digg_system import connect_digg
 from scripts.systems.badger_system import connect_badger
 from tests.helpers import distribute_from_whales
 from tests.sett.fixtures import (
@@ -277,6 +279,17 @@ def digg_distributor_unit():
     # 15% airdropped
     digg.token.transfer(digg.diggDistributor, totalSupply * .15, {"from": deployer})
 
+    return digg
+
+
+@pytest.fixture(scope="function")
+def digg_distributor_prod_unit():
+    badger = connect_badger("deploy-final.json", load_deployer=True, load_keeper=True, load_guardian=True)
+    digg = connect_digg("deploy-final.json")
+    digg.token = digg.uFragments
+
+    badger.add_existing_digg(digg)
+    init_prod_digg(badger, badger.deployer)
     return digg
 
 

--- a/tests/hunt/test_digg_distributor.py
+++ b/tests/hunt/test_digg_distributor.py
@@ -25,7 +25,7 @@ def test_all_claims_full_amount(setup):
 
     claims = []
     loop = asyncio.get_event_loop()
-    with concurrent.futures.ProcessPoolExecutor() as pool:
+    with concurrent.futures.ThreadPoolExecutor() as pool:
         for user, claim in airdrop["claims"].items():
             claims.append(_process_claim(loop, pool, digg, user, claim))
 

--- a/tests/hunt/test_digg_distributor.py
+++ b/tests/hunt/test_digg_distributor.py
@@ -1,0 +1,78 @@
+import asyncio
+import concurrent.futures
+from functools import partial
+
+import json
+import pytest
+from brownie import accounts, reverts
+from rich.console import Console
+
+console = Console()
+
+
+@pytest.fixture(scope="function", autouse="True")
+def setup(digg_distributor_unit):
+    with open("airdrop/digg-test-airdrop.json") as f:
+        airdrop = json.load(f)
+
+    return (digg_distributor_unit, airdrop)
+
+
+# @pytest.mark.skip()
+def test_all_claims_full_amount(setup):
+    digg = setup[0]
+    airdrop = setup[1]
+
+    claims = []
+    loop = asyncio.get_event_loop()
+    with concurrent.futures.ProcessPoolExecutor() as pool:
+        for user, claim in airdrop["claims"].items():
+            claims.append(_process_claim(loop, pool, digg, user, claim))
+
+        loop.run_until_complete(asyncio.gather(*claims))
+
+
+async def _process_claim(loop, pool, digg, user, claim):
+    # Unlock their account (force=True)
+    await loop.run_in_executor(
+        pool,
+        partial(accounts.at, user, force=True),
+    )
+
+    index = claim["index"]
+    amount = int(claim["amount"], 16)
+    proof = claim["proof"]
+    token = digg.token
+    sharesOfPartial = partial(token.sharesOf, user)
+    preShares = await loop.run_in_executor(pool, sharesOfPartial)
+
+    # Make their claim
+    claimPartial = partial(
+        digg.diggDistributor.claim,
+        index,
+        user,
+        amount,
+        proof,
+        {"from": user},
+    )
+    await loop.run_in_executor(pool, claimPartial)
+
+    # Should not be able to claim twice
+    with reverts():
+        await loop.run_in_executor(pool, claimPartial)
+
+    postShares = await loop.run_in_executor(pool, sharesOfPartial)
+
+    # Some share dust will settle in the digg distributor due to
+    # shares <-> frags conversion.
+    transferAmountFrags = await loop.run_in_executor(
+        pool,
+        partial(token.sharesToFragments, amount),
+    )
+    transferAmountShares = await loop.run_in_executor(
+        pool,
+        partial(token.fragmentsToShares, transferAmountFrags),
+    )
+
+    # Ensure their claim is correct.
+    assert preShares + transferAmountShares == postShares


### PR DESCRIPTION
Uses asyncio to make test run slightly faster by not waiting on blocking I/O.

Although tbh it's not super useful here as the work seems rather CPU bound (possibly serialization/deserialization of rpc reqs). 