### PR TITLE
Fix initialize function in RenAdapter upgradeable constructor

### DIFF
--- a/contracts/badger-ren/BadgerRenAdapter.sol
+++ b/contracts/badger-ren/BadgerRenAdapter.sol
@@ -50,7 +50,8 @@ contract BadgerRenAdapter is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         address _exchange,
         address _wbtc,
         uint256[4] memory _feeConfig
-    ) public {
+    ) public initializer {
+        __Ownable_init_unchained();
         governance = _governance;
         rewards = _rewards;
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,6 +1,15 @@
 /**
  * @type import('hardhat/config').HardhatUserConfig
  */
+
+require('hardhat-deploy');
+require('hardhat-deploy-ethers');
+
+require('@nomiclabs/hardhat-etherscan');
+
 module.exports = {
   solidity: "0.6.12",
+  networks: {
+    hardhat: {}
+  }
 };

--- a/helpers/registry.py
+++ b/helpers/registry.py
@@ -161,6 +161,7 @@ curve_registry = DotMap(
             gauge="0x705350c4BcD35c9441419DdD5d2f097d7a55410F",
         ),
         renCrv=DotMap(
+    console.log(values.amount);
             swap="0x93054188d876f558f4a66B2EF1d97d16eDf0895B",
             token="0x49849C98ae39Fff122806C06791Fa73784FB3675",
             gauge="0xB1F2cdeC61db658F091671F5f199635aEF202CAC",

--- a/interfaces/curve/ICurveExchange.sol
+++ b/interfaces/curve/ICurveExchange.sol
@@ -1,0 +1,32 @@
+//  SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0;
+
+interface ICurveExchange {
+    function exchange(
+        int128 i,
+        int128 j,
+        uint256 dx,
+        uint256 min_dy
+    ) external;
+
+    function get_dy(
+        int128,
+        int128 j,
+        uint256 dx
+    ) external view returns (uint256);
+
+    function calc_token_amount(uint256[2] calldata amounts, bool deposit) external returns (uint256 amount);
+
+    function add_liquidity(uint256[2] calldata amounts, uint256 min_mint_amount) external;
+
+    function remove_liquidity(uint256 _amount, uint256[2] calldata min_amounts) external;
+
+    function remove_liquidity_imbalance(uint256[2] calldata amounts, uint256 max_burn_amount) external;
+
+    function remove_liquidity_one_coin(
+        uint256 _token_amounts,
+        int128 i,
+        uint256 min_amount
+    ) external;
+}

--- a/interfaces/ren/IGateway.sol
+++ b/interfaces/ren/IGateway.sol
@@ -1,0 +1,24 @@
+//  SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0;
+
+import "deps/@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IGateway {
+    function mint(
+        bytes32 _pHash,
+        uint256 _amount,
+        bytes32 _nHash,
+        bytes calldata _sig
+    ) external returns (uint256);
+
+    function burn(bytes calldata _to, uint256 _amount) external returns (uint256);
+}
+
+interface IGatewayRegistry {
+    function getGatewayBySymbol(string calldata _tokenSymbol) external view returns (IGateway);
+
+    function getGatewayByToken(address _tokenAddress) external view returns (IGateway);
+
+    function getTokenBySymbol(string calldata _tokenSymbol) external view returns (IERC20);
+}

--- a/interfaces/ren/ISwapRouter.sol
+++ b/interfaces/ren/ISwapRouter.sol
@@ -1,0 +1,14 @@
+//  SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0;
+
+// ISwapRouter hides swapping implementation.
+interface ISwapRouter {
+    function swapTokens(
+        address from,
+        address to,
+        uint256 slippage
+    ) external returns (uint256 amount, bool success);
+
+    function estimateSwapAmount(address from, address to) external returns (uint256 amount);
+}


### PR DESCRIPTION
It is safer to explicitly ensure __Ownable_init() is called appropriately to ensure ownership works properly in the upgradeable framework, and the initializer modifier is added appropriately so we know that it can not be called more than once.

Depending on the version of @openzeppelin/upgrades-core you would want to architect it this way, especially if this ever changed to include multiple inheritance