### PR TITLE
Tree salary expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ rewards-*.json
 
 deploy-1337final.json
 
+salaries/test-*
+
 # vim swap files
 *.swp
 

--- a/contracts/badger-geyser/BadgerTreeV2.sol
+++ b/contracts/badger-geyser/BadgerTreeV2.sol
@@ -333,4 +333,10 @@ contract BadgerTreeV2 is Initializable, AccessControlUpgradeable, ICumulativeMul
             return amount;
         }
     }
+
+    /// @dev test function to get cycle to starting point
+    function setCycle(uint256 x) public {
+        _onlyAdmin();
+        currentCycle = x;
+    }
 }

--- a/contracts/badger-geyser/ContributorLogger.sol
+++ b/contracts/badger-geyser/ContributorLogger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 
 import "deps/@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "deps/@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";

--- a/contracts/badger-geyser/ContributorLogger.sol
+++ b/contracts/badger-geyser/ContributorLogger.sol
@@ -16,6 +16,7 @@ contract ContributorLogger is AccessControlUpgradeable {
         address recipient;
         address token;
         uint256 amount;
+        uint256 amountDuration;
         uint256 startTime;
         uint256 endTime;
     }
@@ -74,11 +75,12 @@ contract ContributorLogger is AccessControlUpgradeable {
             address,
             uint256,
             uint256,
+            uint256,
             uint256
         )
     {
         Entry storage entry = paymentEntries[id];
-        return (entry.recipient, entry.token, entry.amount, entry.startTime, entry.endTime);
+        return (entry.recipient, entry.token, entry.amount, entry.amountDuration, entry.startTime, entry.endTime);
     }
 
     // ===== Permissioned Functions: Manager =====
@@ -92,14 +94,14 @@ contract ContributorLogger is AccessControlUpgradeable {
         address recipient,
         address token,
         uint256 amount,
+        uint256 amountDuration,
         uint256 startTime,
         uint256 endTime
     ) external onlyManager {
         uint256 id = nextId;
         require(startTime >= block.timestamp, "start time cannot be in past");
-        uint256 amountDuration = endTime.sub(startTime);
         nextId = nextId.add(1);
-        paymentEntries[id] = Entry(recipient, token, amount, startTime, endTime);
+        paymentEntries[id] = Entry(recipient, token, amount, amountDuration, startTime, endTime);
         emit CreateEntry(id, recipient, token, amount, amountDuration, startTime, endTime, block.timestamp, block.number);
     }
 
@@ -108,12 +110,13 @@ contract ContributorLogger is AccessControlUpgradeable {
     function updateEntry(
         uint256 id,
         uint256 amount,
+        uint256 amountDuration,
         uint256 startTime,
         uint256 endTime
     ) external onlyManager {
         require(id < nextId, "ID does not exist");
-        uint256 amountDuration = endTime.sub(startTime);
         paymentEntries[id].amount = amount;
+        paymentEntries[id].amountDuration = amountDuration;
         paymentEntries[id].startTime = startTime;
         paymentEntries[id].endTime = endTime;
         emit UpdateEntry(id, amount, amountDuration, startTime, endTime, block.timestamp, block.number);

--- a/scripts/actions/salary/salaries.py
+++ b/scripts/actions/salary/salaries.py
@@ -12,7 +12,7 @@ import brownie
 import os
 
 def __get_data__(logger_address: str, start: int, end: int):
-  calls = [Call(logger_address, ['getEntry(uint256)(address,address,uint256,uint256,uint256)', i], [['recipient_'+str(i), None], ['token_'+str(i), None], ['amount_'+str(i), None], ['startTime_'+str(i), None], ['endTime_'+str(i), None]]) for i in range(start, end)]
+  calls = [Call(logger_address, ['getEntry(uint256)(address,address,uint256,uint256,uint256,uint256)', i], [['recipient_'+str(i), None], ['token_'+str(i), None], ['amount_'+str(i), None], ['amountDuration_'+str(i), None], ['startTime_'+str(i), None], ['endTime_'+str(i), None]]) for i in range(start, end)]
   multi = Multicall(calls)()
 
   result = []
@@ -21,6 +21,7 @@ def __get_data__(logger_address: str, start: int, end: int):
       web3.toChecksumAddress(multi['recipient_'+str(i)]),
       web3.toChecksumAddress(multi['token_'+str(i)]),
       multi['amount_'+str(i)],
+      multi['amountDuration_'+str(i)],
       multi['startTime_'+str(i)],
       multi['endTime_'+str(i)]
     ))
@@ -44,11 +45,9 @@ def fetch_salaries(manager: str, logger_address: str, test=False):
   now = int(time())
 
   for entry in entries:
-    (recipient, token, amount, startTime, endTime) = entry
-    
+    (recipient, token, amount, amountDuration, startTime, endTime) = entry
     if startTime <= now <= endTime or last_paid_timestamp <= endTime <= now:
-      amount_duration = endTime - startTime
-      amount_per_second = amount // amount_duration
+      amount_per_second = amount // amountDuration
       current_period = min(now, endTime) - max(last_paid_timestamp, startTime)
       new_pay = amount_per_second * current_period
 

--- a/scripts/actions/salary/salaries.py
+++ b/scripts/actions/salary/salaries.py
@@ -4,28 +4,47 @@ from time import time
 from datetime import datetime
 from dotmap import DotMap
 
+from helpers.multicall.call import Call
+from helpers.multicall.multicall import Multicall
+
 import json
 import brownie
 import os
 
+def __get_data__(logger_address: str, start: int, end: int):
+  calls = [Call(logger_address, ['getEntry(uint256)(address,address,uint256,uint256,uint256)', i], [['recipient_'+str(i), None], ['token_'+str(i), None], ['amount_'+str(i), None], ['startTime_'+str(i), None], ['endTime_'+str(i), None]]) for i in range(start, end)]
+  multi = Multicall(calls)()
+
+  result = []
+  for i in range(start, end):
+    result.append((
+      web3.toChecksumAddress(multi['recipient_'+str(i)]),
+      web3.toChecksumAddress(multi['token_'+str(i)]),
+      multi['amount_'+str(i)],
+      multi['startTime_'+str(i)],
+      multi['endTime_'+str(i)]
+    ))
+  return result
+
 
 def fetch_salaries(manager: str, logger_address: str, test=False):
-  with open("build/contracts/ContributorLogger.json") as f:
+  with open('build/contracts/ContributorLogger.json') as f:
     logger_abi = json.load(f)['abi']
 
-  logger_contract = brownie.Contract.from_abi("ContributorLogger", logger_address, logger_abi)
-
-  now = int(time())
-  salaries = dict()
+  logger_contract = brownie.Contract.from_abi('ContributorLogger', logger_address, logger_abi)
 
   next_id = logger_contract.nextId()
   last_paid_timestamp = logger_contract.lastPaidTimestamp()
   first_paid_index = logger_contract.firstPaidIndex()
 
-  updated_first_paid_index = first_paid_index
+  entries = __get_data__(logger_address, first_paid_index, next_id)
 
-  for i in range(first_paid_index, next_id):
-    (recipient, token, amount, startTime, endTime) = logger_contract.getEntry(i)
+  updated_first_paid_index = first_paid_index
+  salaries = dict()
+  now = int(time())
+
+  for entry in entries:
+    (recipient, token, amount, startTime, endTime) = entry
     
     if startTime <= now <= endTime or last_paid_timestamp <= endTime <= now:
       amount_duration = endTime - startTime
@@ -50,7 +69,7 @@ def fetch_salaries(manager: str, logger_address: str, test=False):
   salary_json_filename = 'salaries-' + date_now + '.json'
   if test:
     salary_json_filename = 'test-' + salary_json_filename
-  salary_json_filename = "salaries/" + salary_json_filename
+  salary_json_filename = 'salaries/' + salary_json_filename
 
   with open(salary_json_filename, 'w') as salaries_dumped :
     json.dump(salaries, salaries_dumped, indent=4)

--- a/scripts/actions/salary/salaries.py
+++ b/scripts/actions/salary/salaries.py
@@ -1,0 +1,61 @@
+from brownie.network import web3
+from scripts.systems.badger_system import connect_badger
+from time import time 
+from datetime import datetime
+from dotmap import DotMap
+
+import json
+import brownie
+import os
+
+
+def fetch_salaries(manager: str, logger_address: str, test=False):
+  with open("build/contracts/ContributorLogger.json") as f:
+    logger_abi = json.load(f)['abi']
+
+  logger_contract = brownie.Contract.from_abi("ContributorLogger", logger_address, logger_abi)
+
+  now = int(time())
+  salaries = dict()
+
+  next_id = logger_contract.nextId()
+  last_paid_timestamp = logger_contract.lastPaidTimestamp()
+  first_paid_index = logger_contract.firstPaidIndex()
+
+  updated_first_paid_index = first_paid_index
+
+  for i in range(first_paid_index, next_id):
+    (recipient, token, amount, startTime, endTime) = logger_contract.getEntry(i)
+    
+    if startTime <= now <= endTime or last_paid_timestamp <= endTime <= now:
+      amount_duration = endTime - startTime
+      amount_per_second = amount // amount_duration
+      current_period = min(now, endTime) - max(last_paid_timestamp, startTime)
+      new_pay = amount_per_second * current_period
+
+      if not salaries.get(recipient):
+          salaries[recipient] = {}
+      if salaries[recipient].get(token):
+        salaries[recipient][token] += new_pay
+      else:
+        salaries[recipient][token] = new_pay
+        
+    else:
+      updated_first_paid_index += 1
+
+  # Write salary data to json file
+  if not os.path.exists('salaries'):
+    os.makedirs('salaries')
+  date_now = datetime.utcfromtimestamp(now).strftime('%Y-%m-%d %H:%M:%S')
+  salary_json_filename = 'salaries-' + date_now + '.json'
+  if test:
+    salary_json_filename = 'test-' + salary_json_filename
+  salary_json_filename = "salaries/" + salary_json_filename
+
+  with open(salary_json_filename, 'w') as salaries_dumped :
+    json.dump(salaries, salaries_dumped, indent=4)
+
+  # Set last paid timestamp on chain
+  logger_contract.setCheckpoint(now, updated_first_paid_index, { 'from': manager })
+
+  return salary_json_filename

--- a/tests/rewards_tree/test_rewards_multi_cycle.py
+++ b/tests/rewards_tree/test_rewards_multi_cycle.py
@@ -32,22 +32,7 @@ def test_rewards_flow(setup):
 
     rewardsContract = admin.deploy(BadgerTreeV2)
     rewardsContract.initialize(admin, proposer, validator)
-
-    console.print("[yellow]You may need to manually set the cycle in the contract for this test to work. See the comment titled 'SETTING CORRECT CYCLE'[/yellow]")
-    '''
-    SETTING CORRECT CYCLE
-    =========================
-    1. Add the following function to the BadgerTreeV2 contract:
-
-    /// @dev test function to get cycle to starting point
-    function setCycle(uint256 n) public {
-        _onlyAdmin();
-        currentCycle = n;
-    }
-
-    2. Uncomment the next line to set the cycle in the test contract:
-    '''
-    # rewardsContract.setCycle(1296, {'from': admin})
+    rewardsContract.setCycle(1296, {'from': admin})
 
     contentHash1 = "0xe8e31919bd92024a0437852392695f5424932b2d1b041ab45c319de7ce42fda0"
     contentHash2 = "0xe84f535a2581589e2c0b62040926d6599d14c436da24ab8fac5e2c86467721aa"

--- a/tests/rewards_tree/test_salaries.py
+++ b/tests/rewards_tree/test_salaries.py
@@ -1,0 +1,175 @@
+import json
+from os import wait
+import secrets
+
+import brownie
+from dotmap import DotMap
+import pytest
+from decimal import Decimal
+
+import pprint
+
+from brownie import *
+from helpers.constants import *
+from helpers.registry import registry
+from rich.console import Console
+from time import time, sleep
+
+from scripts.actions.salary.salaries import fetch_salaries
+
+console = Console()
+
+badger_token = "0x3472A5A71965499acd81997a54BBA8D852C6E53d"
+
+@pytest.fixture(scope="function", autouse="True")
+def setup():
+    from assistant.rewards import rewards_assistant
+    return rewards_assistant
+
+# @pytest.mark.skip()
+def test_salaries(setup):
+    rewards_assistant = setup
+    ContributorLogger = rewards_assistant.ContributorLogger
+
+    admin, manager = accounts[:2]
+
+    loggerContract = admin.deploy(ContributorLogger)
+    loggerContract.initialize(admin, admin, manager)
+
+    # salary period ends in the future
+    console.print("Testing a salary period that ends after the check is made")
+    now = int(time()) + 1
+    first_entry = {
+      "recipient": accounts[2].address,
+      "token": badger_token,
+      "amount": 100000,
+      "startTime": now,
+      "endTime": now + 10,
+    }
+    loggerContract.createEntry(
+      first_entry["recipient"],
+      first_entry["token"],
+      first_entry["amount"],
+      first_entry["startTime"],
+      first_entry["endTime"],
+      { "from": manager }
+    )
+
+    wait_time = 5
+    sleep(wait_time)
+
+    salary_json_filename = fetch_salaries(manager, loggerContract.address, True)
+
+    with open(salary_json_filename) as f:
+      salary_json = json.load(f)
+
+    # depending on when the block gets mined it could be plus or minus one second
+    payouts = [
+      int((wait_time) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"]))),
+      int((wait_time + 1) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"]))),
+      int((wait_time - 1) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"])))
+    ]
+    expected_value1 = salary_json[first_entry["recipient"]][first_entry["token"]]
+    assert (expected_value1 == payouts[0] or expected_value1 == payouts[1] or expected_value1 == payouts[2])
+
+    sleep(wait_time + 1)
+
+    # checking after salary time ended
+    console.print("Testing that salary is correct after full period has elapsed")
+    salary_json_filename = fetch_salaries(manager, loggerContract.address, True)
+
+    with open(salary_json_filename) as f:
+      salary_json = json.load(f)
+
+    # depending on when the block gets mined it could be one second off
+    payouts = [
+      int((wait_time) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"]))),
+      int((wait_time + 1) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"]))),
+      int((wait_time - 1) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"])))
+    ]
+    expected_value2 = salary_json[first_entry["recipient"]][first_entry["token"]]
+    assert (expected_value2 == payouts[0] or expected_value2 == payouts[1] or expected_value2 == payouts[2])
+    assert expected_value1 + expected_value2 == first_entry["amount"]
+
+    # multiple salaries in the same time period
+    console.print("Testing two salaries overlapping each other")
+    now1 = int(time()) + 1
+    first_entry = {
+      "recipient": accounts[2].address,
+      "token": badger_token,
+      "amount": 100000,
+      "startTime": now1,
+      "endTime": now1 + 5,
+    }
+    loggerContract.createEntry(
+      first_entry["recipient"],
+      first_entry["token"],
+      first_entry["amount"],
+      first_entry["startTime"],
+      first_entry["endTime"],
+      { "from": manager }
+    )
+    now2 = int(time()) + 1
+    second_entry = {
+      "recipient": accounts[3].address,
+      "token": badger_token,
+      "amount": 1580945,
+      "startTime": now2,
+      "endTime": now2 + 10,
+    }
+    loggerContract.createEntry(
+      second_entry["recipient"],
+      second_entry["token"],
+      second_entry["amount"],
+      second_entry["startTime"],
+      second_entry["endTime"],
+      { "from": manager }
+    )
+
+    wait_time = 8
+    sleep(wait_time)
+
+    salary_json_filename = fetch_salaries(manager, loggerContract.address, True)
+
+    with open(salary_json_filename) as f:
+      salary_json = json.load(f)
+
+    # should have received entire payout
+    assert salary_json[first_entry["recipient"]][first_entry["token"]] == first_entry["amount"]
+
+    # should have received a partial payout (may be off by +/- 1 second)
+    payouts = [
+      int((wait_time) * (second_entry["amount"] // (second_entry["endTime"] - second_entry["startTime"]))),
+      int((wait_time + 1) * (second_entry["amount"] // (second_entry["endTime"] - second_entry["startTime"]))),
+      int((wait_time - 1) * (second_entry["amount"] // (second_entry["endTime"] - second_entry["startTime"])))
+    ]
+    expected_value = salary_json[second_entry["recipient"]][second_entry["token"]]
+    assert (expected_value == payouts[0] or expected_value == payouts[1] or expected_value == payouts[2])
+
+    # after 5 more seconds there should only be one salary entry
+    console.print("Testing after the first period has ended")
+    last_paid_timestamp1 = loggerContract.lastPaidTimestamp()
+    wait_time = 5
+    sleep(wait_time)
+
+    salary_json_filename = fetch_salaries(manager, loggerContract.address, True)
+
+    duration = second_entry["endTime"] - last_paid_timestamp1
+    with open(salary_json_filename) as f:
+      salary_json = json.load(f)
+
+    # should have received a partial payout
+    expected_value = salary_json[second_entry["recipient"]][second_entry["token"]]
+    payout = int((duration) * (second_entry["amount"] // (second_entry["endTime"] - second_entry["startTime"])))
+    assert expected_value == payout
+
+    # should be no more entries when called again
+    console.print("Testing with no more salaries to be paid out")
+    wait_time = 1
+    sleep(wait_time)
+
+    salary_json_filename = fetch_salaries(manager, loggerContract.address, True)
+    with open(salary_json_filename) as f:
+      salary_json = json.load(f)
+    
+    assert salary_json == {}

--- a/tests/rewards_tree/test_salaries.py
+++ b/tests/rewards_tree/test_salaries.py
@@ -19,9 +19,9 @@ from scripts.actions.salary.salaries import fetch_salaries
 
 console = Console()
 
-badger_token = "0x3472A5A71965499acd81997a54BBA8D852C6E53d"
+badger_token = '0x3472A5A71965499acd81997a54BBA8D852C6E53d'
 
-@pytest.fixture(scope="function", autouse="True")
+@pytest.fixture(scope='function', autouse='True')
 def setup():
     from assistant.rewards import rewards_assistant
     return rewards_assistant
@@ -37,22 +37,22 @@ def test_salaries(setup):
     loggerContract.initialize(admin, admin, manager)
 
     # salary period ends in the future
-    console.print("Testing a salary period that ends after the check is made")
+    console.print('Testing a salary period that ends after the check is made')
     now = int(time()) + 1
     first_entry = {
-      "recipient": accounts[2].address,
-      "token": badger_token,
-      "amount": 100000,
-      "startTime": now,
-      "endTime": now + 10,
+      'recipient': accounts[2].address,
+      'token': badger_token,
+      'amount': 100000,
+      'startTime': now,
+      'endTime': now + 10,
     }
     loggerContract.createEntry(
-      first_entry["recipient"],
-      first_entry["token"],
-      first_entry["amount"],
-      first_entry["startTime"],
-      first_entry["endTime"],
-      { "from": manager }
+      first_entry['recipient'],
+      first_entry['token'],
+      first_entry['amount'],
+      first_entry['startTime'],
+      first_entry['endTime'],
+      { 'from': manager }
     )
 
     wait_time = 5
@@ -65,17 +65,17 @@ def test_salaries(setup):
 
     # depending on when the block gets mined it could be plus or minus one second
     payouts = [
-      int((wait_time) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"]))),
-      int((wait_time + 1) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"]))),
-      int((wait_time - 1) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"])))
+      int((wait_time) * (first_entry['amount'] // (first_entry['endTime'] - first_entry['startTime']))),
+      int((wait_time + 1) * (first_entry['amount'] // (first_entry['endTime'] - first_entry['startTime']))),
+      int((wait_time - 1) * (first_entry['amount'] // (first_entry['endTime'] - first_entry['startTime'])))
     ]
-    expected_value1 = salary_json[first_entry["recipient"]][first_entry["token"]]
+    expected_value1 = salary_json[first_entry['recipient']][first_entry['token']]
     assert (expected_value1 == payouts[0] or expected_value1 == payouts[1] or expected_value1 == payouts[2])
 
     sleep(wait_time + 1)
 
     # checking after salary time ended
-    console.print("Testing that salary is correct after full period has elapsed")
+    console.print('Testing that salary is correct after full period has elapsed')
     salary_json_filename = fetch_salaries(manager, loggerContract.address, True)
 
     with open(salary_json_filename) as f:
@@ -83,47 +83,47 @@ def test_salaries(setup):
 
     # depending on when the block gets mined it could be one second off
     payouts = [
-      int((wait_time) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"]))),
-      int((wait_time + 1) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"]))),
-      int((wait_time - 1) * (first_entry["amount"] // (first_entry["endTime"] - first_entry["startTime"])))
+      int((wait_time) * (first_entry['amount'] // (first_entry['endTime'] - first_entry['startTime']))),
+      int((wait_time + 1) * (first_entry['amount'] // (first_entry['endTime'] - first_entry['startTime']))),
+      int((wait_time - 1) * (first_entry['amount'] // (first_entry['endTime'] - first_entry['startTime'])))
     ]
-    expected_value2 = salary_json[first_entry["recipient"]][first_entry["token"]]
+    expected_value2 = salary_json[first_entry['recipient']][first_entry['token']]
     assert (expected_value2 == payouts[0] or expected_value2 == payouts[1] or expected_value2 == payouts[2])
-    assert expected_value1 + expected_value2 == first_entry["amount"]
+    assert expected_value1 + expected_value2 == first_entry['amount']
 
     # multiple salaries in the same time period
-    console.print("Testing two salaries overlapping each other")
+    console.print('Testing two salaries overlapping each other')
     now1 = int(time()) + 1
     first_entry = {
-      "recipient": accounts[2].address,
-      "token": badger_token,
-      "amount": 100000,
-      "startTime": now1,
-      "endTime": now1 + 5,
+      'recipient': accounts[2].address,
+      'token': badger_token,
+      'amount': 100000,
+      'startTime': now1,
+      'endTime': now1 + 5,
     }
     loggerContract.createEntry(
-      first_entry["recipient"],
-      first_entry["token"],
-      first_entry["amount"],
-      first_entry["startTime"],
-      first_entry["endTime"],
-      { "from": manager }
+      first_entry['recipient'],
+      first_entry['token'],
+      first_entry['amount'],
+      first_entry['startTime'],
+      first_entry['endTime'],
+      { 'from': manager }
     )
     now2 = int(time()) + 1
     second_entry = {
-      "recipient": accounts[3].address,
-      "token": badger_token,
-      "amount": 1580945,
-      "startTime": now2,
-      "endTime": now2 + 10,
+      'recipient': accounts[3].address,
+      'token': badger_token,
+      'amount': 650,
+      'startTime': now2,
+      'endTime': now2 + 10,
     }
     loggerContract.createEntry(
-      second_entry["recipient"],
-      second_entry["token"],
-      second_entry["amount"],
-      second_entry["startTime"],
-      second_entry["endTime"],
-      { "from": manager }
+      second_entry['recipient'],
+      second_entry['token'],
+      second_entry['amount'],
+      second_entry['startTime'],
+      second_entry['endTime'],
+      { 'from': manager }
     )
 
     wait_time = 8
@@ -134,37 +134,38 @@ def test_salaries(setup):
     with open(salary_json_filename) as f:
       salary_json = json.load(f)
 
-    # should have received entire payout
-    assert salary_json[first_entry["recipient"]][first_entry["token"]] == first_entry["amount"]
+    # first address should have received entire payout
+    assert salary_json[first_entry['recipient']][first_entry['token']] == first_entry['amount']
 
-    # should have received a partial payout (may be off by +/- 1 second)
+    # second address should have received a partial payout (may be off by +/- 1 second)
     payouts = [
-      int((wait_time) * (second_entry["amount"] // (second_entry["endTime"] - second_entry["startTime"]))),
-      int((wait_time + 1) * (second_entry["amount"] // (second_entry["endTime"] - second_entry["startTime"]))),
-      int((wait_time - 1) * (second_entry["amount"] // (second_entry["endTime"] - second_entry["startTime"])))
+      int((wait_time) * (second_entry['amount'] // (second_entry['endTime'] - second_entry['startTime']))),
+      int((wait_time + 1) * (second_entry['amount'] // (second_entry['endTime'] - second_entry['startTime']))),
+      int((wait_time - 1) * (second_entry['amount'] // (second_entry['endTime'] - second_entry['startTime'])))
     ]
-    expected_value = salary_json[second_entry["recipient"]][second_entry["token"]]
-    assert (expected_value == payouts[0] or expected_value == payouts[1] or expected_value == payouts[2])
+    expected_value1 = salary_json[second_entry['recipient']][second_entry['token']]
+    assert (expected_value1 == payouts[0] or expected_value1 == payouts[1] or expected_value1 == payouts[2])
 
     # after 5 more seconds there should only be one salary entry
-    console.print("Testing after the first period has ended")
-    last_paid_timestamp1 = loggerContract.lastPaidTimestamp()
+    console.print('Testing after the first period has ended')
+    last_paid_timestamp = loggerContract.lastPaidTimestamp()
     wait_time = 5
     sleep(wait_time)
 
     salary_json_filename = fetch_salaries(manager, loggerContract.address, True)
 
-    duration = second_entry["endTime"] - last_paid_timestamp1
+    duration = second_entry['endTime'] - last_paid_timestamp
     with open(salary_json_filename) as f:
       salary_json = json.load(f)
 
     # should have received a partial payout
-    expected_value = salary_json[second_entry["recipient"]][second_entry["token"]]
-    payout = int((duration) * (second_entry["amount"] // (second_entry["endTime"] - second_entry["startTime"])))
-    assert expected_value == payout
+    expected_value2 = salary_json[second_entry['recipient']][second_entry['token']]
+    payout = int((duration) * (second_entry['amount'] // (second_entry['endTime'] - second_entry['startTime'])))
+    assert expected_value2 == payout
+    assert expected_value1 + expected_value2 == second_entry['amount']
 
     # should be no more entries when called again
-    console.print("Testing with no more salaries to be paid out")
+    console.print('Testing with no more salaries to be paid out')
     wait_time = 1
     sleep(wait_time)
 

--- a/tests/rewards_tree/test_salaries.py
+++ b/tests/rewards_tree/test_salaries.py
@@ -43,6 +43,7 @@ def test_salaries(setup):
       'recipient': accounts[2].address,
       'token': badger_token,
       'amount': 100000,
+      'amountDuration': 10,
       'startTime': now,
       'endTime': now + 10,
     }
@@ -50,6 +51,7 @@ def test_salaries(setup):
       first_entry['recipient'],
       first_entry['token'],
       first_entry['amount'],
+      first_entry['amountDuration'],
       first_entry['startTime'],
       first_entry['endTime'],
       { 'from': manager }
@@ -98,6 +100,7 @@ def test_salaries(setup):
       'recipient': accounts[2].address,
       'token': badger_token,
       'amount': 100000,
+      'amountDuration': 5,
       'startTime': now1,
       'endTime': now1 + 5,
     }
@@ -105,6 +108,7 @@ def test_salaries(setup):
       first_entry['recipient'],
       first_entry['token'],
       first_entry['amount'],
+      first_entry['amountDuration'],
       first_entry['startTime'],
       first_entry['endTime'],
       { 'from': manager }
@@ -114,6 +118,7 @@ def test_salaries(setup):
       'recipient': accounts[3].address,
       'token': badger_token,
       'amount': 650,
+      'amountDuration': 10,
       'startTime': now2,
       'endTime': now2 + 10,
     }
@@ -121,6 +126,7 @@ def test_salaries(setup):
       second_entry['recipient'],
       second_entry['token'],
       second_entry['amount'],
+      second_entry['amountDuration'],
       second_entry['startTime'],
       second_entry['endTime'],
       { 'from': manager }
@@ -173,4 +179,92 @@ def test_salaries(setup):
     with open(salary_json_filename) as f:
       salary_json = json.load(f)
     
+    assert salary_json == {}
+
+    # unlimited length salary period
+    console.print('Testing a salary period that lasts forever')
+    now = int(time()) + 1
+    infinite_entry = {
+      'recipient': accounts[3].address,
+      'token': badger_token,
+      'amount': 200000,
+      'amountDuration': 10,
+      'startTime': now,
+      'endTime': 2**256-1,
+    }
+    tx = loggerContract.createEntry(
+      infinite_entry['recipient'],
+      infinite_entry['token'],
+      infinite_entry['amount'],
+      infinite_entry['amountDuration'],
+      infinite_entry['startTime'],
+      infinite_entry['endTime'],
+      { 'from': manager }
+    )
+
+    id = tx.events['CreateEntry']['id']
+
+    wait_time = 5
+    sleep(wait_time)
+
+    salary_json_filename = fetch_salaries(manager, loggerContract.address, True)
+
+    with open(salary_json_filename) as f:
+      salary_json = json.load(f)
+
+    # depending on when the block gets mined it could be plus or minus one second
+    payouts = [
+      int((wait_time) * (infinite_entry['amount'] // (infinite_entry['amountDuration']))),
+      int((wait_time + 1) * (infinite_entry['amount'] // (infinite_entry['amountDuration']))),
+      int((wait_time - 1) * (infinite_entry['amount'] // (infinite_entry['amountDuration'])))
+    ]
+    expected_value1 = salary_json[infinite_entry['recipient']][infinite_entry['token']]
+    assert (expected_value1 == payouts[0] or expected_value1 == payouts[1] or expected_value1 == payouts[2])
+
+    # update entry
+    console.print('Testing updating salary period')
+    infinite_entry_updated = {
+      'recipient': infinite_entry['recipient'],
+      'token': infinite_entry['token'],
+      'amount': 5555555,
+      'amountDuration': 5,
+      'startTime': now,
+      'endTime': 2**256-1,
+    }
+    loggerContract.updateEntry(
+      id,
+      infinite_entry_updated['amount'],
+      infinite_entry_updated['amountDuration'],
+      infinite_entry_updated['startTime'],
+      infinite_entry_updated['endTime'],
+      { 'from': manager }
+    )
+
+    wait_time = 5
+    sleep(wait_time)
+
+    salary_json_filename = fetch_salaries(manager, loggerContract.address, True)
+
+    with open(salary_json_filename) as f:
+      salary_json = json.load(f)
+
+    # depending on when the block gets mined it could be plus or minus one second
+    payouts = [
+      int((wait_time) * (infinite_entry_updated['amount'] // (infinite_entry_updated['amountDuration']))),
+      int((wait_time + 1) * (infinite_entry_updated['amount'] // (infinite_entry_updated['amountDuration']))),
+      int((wait_time - 1) * (infinite_entry_updated['amount'] // (infinite_entry_updated['amountDuration'])))
+    ]
+    expected_value1 = salary_json[infinite_entry_updated['recipient']][infinite_entry_updated['token']]
+    assert (expected_value1 == payouts[0] or expected_value1 == payouts[1] or expected_value1 == payouts[2])
+
+    # delete an entry
+    console.print('Testing deletion')
+
+    loggerContract.deleteEntry(id, { 'from': manager })
+
+    salary_json_filename = fetch_salaries(manager, loggerContract.address, True)
+
+    with open(salary_json_filename) as f:
+      salary_json = json.load(f)
+
     assert salary_json == {}


### PR DESCRIPTION
Contributor Logger contract functions as a database for salary entries:

- payment entries held on chain in a mapping
- `scripts/actions/salary/salaries.py` reads on chain data and generates json file of payments for the current period then writes a checkpoint on chain for the time period processed
- tests added at `tests/rewards_tree/test_salaries.py`