### PR TITLE
QA fixes

### DIFF
--- a/helpers/gas_utils.py
+++ b/helpers/gas_utils.py
@@ -77,4 +77,3 @@ class GasStrategies:
 
 
 gas_strategies = GasStrategies()
-gas_strategies.set_default(gas_strategies.fast)

--- a/helpers/sett/SnapshotManager.py
+++ b/helpers/sett/SnapshotManager.py
@@ -307,81 +307,99 @@ class SnapshotManager:
                 before, after, {"user": user, "amount": userBalance}, tx
             )
 
-    def estimateProfitTendViaManager(self, key, strategy, overrides):
-        gas_estimate = self.badger.badgerRewardsManager.tend.estimate_gas(
-            strategy, overrides
-        )
-        gas_cost = web3.fromWei(gas_strategies.gas_cost(gas_estimate), "ether")
-        earnings = get_tend_earnings_manager(self.badger, self.strategy, key, overrides)
-        if earnings == "skip":
-            return 0
+    def estimateProfitTendViaManager(self, key, strategy, overrides, min_profit):
+        try:
+            gas_estimate = self.badger.badgerRewardsManager.tend.estimate_gas(
+                strategy, overrides
+            )
+            gas_cost = web3.fromWei(gas_strategies.gas_cost(gas_estimate), "ether")
+            earnings = get_tend_earnings_manager(
+                self.badger, self.strategy, key, overrides
+            )
+            if earnings == "skip":
+                return min_profit
 
-        profit = decimal.Decimal(earnings) - gas_cost
-        console.log(
-            "expected gas cost:",
-            gas_cost,
-            "expected earnings:",
-            earnings,
-            "expected profits",
-            profit,
-        )
-        return profit
+            profit = decimal.Decimal(earnings) - gas_cost
+            console.log(
+                "expected gas cost:",
+                gas_cost,
+                "expected earnings:",
+                earnings,
+                "expected profits",
+                profit,
+            )
+            return profit
+        except:
+            print("profit estimation failed")
+            return min_profit
 
-    def estimateProfitTend(self, key, overrides):
-        gas_estimate = self.strategy.tend.estimate_gas(overrides)
-        gas_cost = web3.fromWei(gas_strategies.gas_cost(gas_estimate), "ether")
-        earnings = get_tend_earnings(self.strategy, key, overrides)
-        if earnings == "skip":
-            return 0
+    def estimateProfitTend(self, key, overrides, min_profit):
+        try:
+            gas_estimate = self.strategy.tend.estimate_gas(overrides)
+            gas_cost = web3.fromWei(gas_strategies.gas_cost(gas_estimate), "ether")
+            earnings = get_tend_earnings(self.strategy, key, overrides)
+            if earnings == "skip":
+                return min_profit
 
-        profit = decimal.Decimal(earnings) - gas_cost
-        console.log(
-            "expected gas cost:",
-            gas_cost,
-            "expected earnings:",
-            earnings,
-            "expected profits",
-            profit,
-        )
-        return profit
+            profit = decimal.Decimal(earnings) - gas_cost
+            console.log(
+                "expected gas cost:",
+                gas_cost,
+                "expected earnings:",
+                earnings,
+                "expected profits",
+                profit,
+            )
+            return profit
+        except:
+            print("profit estimation failed")
+            return min_profit
 
-    def estimateProfitHarvestViaManager(self, key, strategy, overrides):
-        gas_estimate = self.badger.badgerRewardsManager.harvest.estimate_gas(
-            strategy, overrides
-        )
-        gas_cost = web3.fromWei(gas_strategies.gas_cost(gas_estimate), "ether")
-        earnings = get_harvest_earnings(self.strategy, key, overrides)
-        if earnings == "skip":
-            return 0
+    def estimateProfitHarvestViaManager(self, key, strategy, overrides, min_profit):
+        try:
+            gas_estimate = self.badger.badgerRewardsManager.harvest.estimate_gas(
+                strategy, overrides
+            )
+            gas_cost = web3.fromWei(gas_strategies.gas_cost(gas_estimate), "ether")
+            earnings = get_harvest_earnings(self.strategy, key, overrides)
+            if earnings == "skip":
+                return min_profit
 
-        profit = decimal.Decimal(earnings) - gas_cost
-        console.log(
-            "expected gas cost:",
-            gas_cost,
-            "expected earnings:",
-            earnings,
-            "expected profits",
-            profit,
-        )
-        return profit
+            profit = decimal.Decimal(earnings) - gas_cost
+            console.log(
+                "expected gas cost:",
+                gas_cost,
+                "expected earnings:",
+                earnings,
+                "expected profits",
+                profit,
+            )
+            return profit
+        except:
+            print("profit estimation failed")
+            return min_profit
 
-    def estimateProfitHarvest(self, key, overrides):
-        gas_estimate = self.strategy.harvest.estimate_gas(overrides)
-        gas_cost = web3.fromWei(gas_strategies.gas_cost(gas_estimate), "ether")
-        earnings = get_harvest_earnings(self.strategy, key, overrides)
-        if earnings == "skip":
-            return 0
+    def estimateProfitHarvest(self, key, overrides, min_profit):
+        try:
+            gas_estimate = self.strategy.harvest.estimate_gas(overrides)
+            gas_cost = web3.fromWei(gas_strategies.gas_cost(gas_estimate), "ether")
+            earnings = get_harvest_earnings(self.strategy, key, overrides)
+            if earnings == "skip":
+                return min_profit
 
-        profit = decimal.Decimal(earnings) - gas_cost
-        console.log(
-            "expected gas cost:",
-            gas_cost,
-            "expected earnings:",
-            earnings,
-            "expected profits",
-            profit,
-        )
-        return profit
+            profit = decimal.Decimal(earnings) - gas_cost
+            console.log(
+                "expected gas cost:",
+                gas_cost,
+                "expected earnings:",
+                earnings,
+                "expected profits",
+                profit,
+            )
+            return profit
+        except:
+            print("profit estimation failed")
+            return min_profit
 
     def format(self, key, value):
         if type(value) is int:

--- a/helpers/tx_timer.py
+++ b/helpers/tx_timer.py
@@ -36,12 +36,14 @@ class TxTimer:
         self.timer_tick = timer_tick
         self.waiting = False
         self.sender = None
-        self.webhook = os.environ["TX_TIMER_WEBHOOK"]
+        self.webhook = os.environ.get("TX_TIMER_WEBHOOK")
         self.tx_type = ""
 
     def alert(self, msg: str) -> None:
-        print(msg)
-        requests.post(self.webhook, {"content": msg})
+        if self.webhook:
+            requests.post(self.webhook, {"content": msg})
+        else:
+            print("No webhook supplied")
 
     def track_tx(self) -> None:
         """

--- a/scripts/keeper/harvest.py
+++ b/scripts/keeper/harvest.py
@@ -41,6 +41,7 @@ def harvest_all(badger: BadgerSystem, skip, min_profit=0):
                 key,
                 strategy,
                 {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
+                min_profit,
             )
             if estimated_profit >= min_profit:
                 snap.settHarvestViaManager(
@@ -50,7 +51,9 @@ def harvest_all(badger: BadgerSystem, skip, min_profit=0):
                 )
         else:
             estimated_profit = snap.estimateProfitHarvest(
-                key, {"from": keeper, "gas_limit": 2000000, "allow_revert": True}
+                key,
+                {"from": keeper, "gas_limit": 2000000, "allow_revert": True},
+                min_profit,
             )
             if estimated_profit >= min_profit:
                 snap.settHarvest(

--- a/scripts/keeper/tend.py
+++ b/scripts/keeper/tend.py
@@ -40,20 +40,23 @@ def tend_all(badger: BadgerSystem, skip, min_profit=0):
 
         if strategy.keeper() == badger.badgerRewardsManager:
             estimated_profit = snap.estimateProfitTendViaManager(
-                key, strategy, {"from": keeper, "gas_limit": 1000000}
+                key, strategy, {"from": keeper, "gas_limit": 1000000}, min_profit
             )
             if estimated_profit >= min_profit:
                 snap.settTendViaManager(
-                    strategy, {"from": keeper, "gas_limit": 1000000}, confirm=False,
+                    strategy,
+                    {"from": keeper, "gas_limit": 1000000},
+                    confirm=False,
                 )
         else:
             keeper = accounts.at(strategy.keeper())
             estimated_profit = snap.estimateProfitTend(
-                key, {"from": keeper, "gas_limit": 1000000}
+                key, {"from": keeper, "gas_limit": 1000000}, min_profit
             )
             if estimated_profit >= min_profit:
                 snap.settTend(
-                    {"from": keeper, "gas_limit": 1000000}, confirm=False,
+                    {"from": keeper, "gas_limit": 1000000},
+                    confirm=False,
                 )
 
         tx_wait()


### PR DESCRIPTION
**What was wrong:**
- tx timer class would cause crash if there was no `TX_TIMER_WEBHOOK` in .env
- keeper functions that performed a profit estimation would cause crash if gas strategy couldn't be fetched

**How it was fixed:**
- tx timer class will do nothing if there is no `TX_TIMER_WEBHOOK` in .env
- profit estimation functions wrapped in try/except, harvest and tend bots will ignore estimation and continue running if an exception is raised i.e. gas price couldn't be fetched