### PR TITLE
Add helper for exchange in metapool factories - Curve.fi

### DIFF
--- a/interfaces/curve/ICurveFactory.sol
+++ b/interfaces/curve/ICurveFactory.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0 <0.8.0;
+
+interface ICurveFactory {
+    function find_pool_for_coins(address _from, address _to, uint256 _index)
+        external
+        returns (address);
+
+    function get_coin_indices(
+        address _pool,
+        address _from,
+        address _to
+    )
+        external
+        returns (
+            int128,
+            int128,
+            bool
+        );
+}


### PR DESCRIPTION
This is an attempt to update the existing CurveSwapper contract to allow swaps in the curve.fi metapools.

[Arguments](https://github.com/Badger-Finance/badger-system/blob/feat/curve_swapper_helper/contracts/badger-sett/libraries/CurveSwapper.sol#L27):

1) _from: token from which we are swapping from
2) _to: our token of interest
3) _index: index of the pool of interest for our swap, the same pair can have multiple pools available, so needs to be specify.
4) _dx: amount which will be swapped

Regarding argumen 3), I think that the index, could be an `uint256 public curveIndexPool` within each specific strategy contract, which will use the metapool curve pools. In that way, in the case that we choose the default index (i.e, 0 or different), and after 1 month the index 2 is the most liquid and make most sense to swap thru, we could just update a contract via a permission method (i.e,  _onlyGovernance();) to update the `curveIndexPool` by using something like `function setCurveIndexPool(uint256 _newIndex) external` :

![pic_share](https://user-images.githubusercontent.com/84875062/132248931-1275bc66-2431-4ef3-8281-c04c106d4792.png)

In this case all are for the same pair **(cvxcrv, crv)**, but only this [pool](https://etherscan.io/address/0x9D0464996170c6B9e75eED71c68B99dDEDf279e8) will make sense to swap thru.
